### PR TITLE
#4 Add temporal CLI container to docker compose

### DIFF
--- a/temporal-examples/docker-compose.yml
+++ b/temporal-examples/docker-compose.yml
@@ -52,6 +52,8 @@ services:
     entrypoint: ["sleep", "infinity"]
     environment:
       TEMPORAL_ADDRESS: temporal:7233
+    volumes:
+    - ./scripts:/scripts
 
   temporal-ui:
     container_name: temporal-ui

--- a/temporal-examples/scripts/start_and_signal_workflow.sh
+++ b/temporal-examples/scripts/start_and_signal_workflow.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+WORKFLOW_ID="$(date +%s)-$RANDOM"
+
+echo "Starting workflow with ID: $WORKFLOW_ID"
+temporal workflow start --type WaitingSignalWorkflow --task-queue example --workflow-id "$WORKFLOW_ID"
+
+sleep 2
+read -p "Enter your name to signal the workflow: " SIGNAL_INPUT
+
+# Send the signal to the workflow
+temporal workflow signal --workflow-id "$WORKFLOW_ID" --name Continue --input "\"$SIGNAL_INPUT\""
+
+echo "Signal sent to workflow $WORKFLOW_ID"
+
+

--- a/temporal-examples/scripts/start_example_workflow.sh
+++ b/temporal-examples/scripts/start_example_workflow.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo "Starting workflow of type ExampleWorkflow"
+temporal workflow start --type ExampleWorkflow --task-queue example
+sleep 2
+# List all workflows
+temporal workflow list


### PR DESCRIPTION
#4 This PR adds a new container in the docker compose that contains the [Temporal CLI](https://docs.temporal.io/cli). 

To use it, once you start all containers using `docker compose up -d`, you can `exec` into the `temporal-cli` container either via the command line or Docker Desktop and use the Temporal CLI without having to install it.

For example:
<img width="529" height="205" alt="image" src="https://github.com/user-attachments/assets/de411328-d080-4236-9d24-cabfbb55c907" />
Result:
<img width="1115" height="540" alt="image" src="https://github.com/user-attachments/assets/07bfd105-aac0-4dc8-a42f-0c614266fe15" />

Also added a couple of example scripts using the temporal CLI. One starts an example workflow and then lists all the workflows of the default namespace.

The other starts a workflow waiting for a signal and then asks the user to send that signal.
<img width="789" height="351" alt="image" src="https://github.com/user-attachments/assets/4b0672a6-4582-4591-8efd-2b5c899945fe" />
