### PR TITLE
Adds the grafana stack to the microservices worker

### DIFF
--- a/temporal-examples/microservice-worker/AutoFac/Modules/TemporalWorkerConfigurationModule.cs
+++ b/temporal-examples/microservice-worker/AutoFac/Modules/TemporalWorkerConfigurationModule.cs
@@ -2,7 +2,9 @@
 using Autofac.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Temporalio.Client;
 using Temporalio.Extensions.Hosting;
+using Temporalio.Extensions.OpenTelemetry;
 using Temporalio.Runtime;
 using Workflows;
 
@@ -29,6 +31,8 @@ namespace TemporalWorker.AutoFac.Modules
             // This is using a different queue to the other worker
             var taskQueue = temporalConfig["TaskQueue"] ?? "microservice-queue";
 
+            var assemblyName = typeof(TemporalClient).Assembly.GetName();
+
             services
                 .AddTemporalClient(clientHost, clientNamespace)
                 .Configure(options =>
@@ -45,6 +49,8 @@ namespace TemporalWorker.AutoFac.Modules
                             },
                         }
                     );
+
+                    options.Interceptors = [new TracingInterceptor()];
                 });
 
             var workerBuilder = services

--- a/temporal-examples/workflows/Microservice.workflow.cs
+++ b/temporal-examples/workflows/Microservice.workflow.cs
@@ -30,7 +30,7 @@ public class MicroservicesWorkflow
         );
 
         bool result = await Workflow.ExecuteActivityAsync(
-            () => MicroserviceActivities.ValidateTransition("Transition to validate"),
+            (MicroserviceActivities a) => a.ValidateTransition("Transition to validate"),
             new ActivityOptions
             {
                 StartToCloseTimeout = TimeSpan.FromMinutes(5),
@@ -40,7 +40,7 @@ public class MicroservicesWorkflow
         );
 
         await Workflow.ExecuteActivityAsync(
-            () => MicroserviceActivities.CreateSecondaryCosts(),
+            (MicroserviceActivities a) => a.CreateSecondaryCosts(),
             new ActivityOptions
             {
                 StartToCloseTimeout = TimeSpan.FromMinutes(5),
@@ -50,7 +50,7 @@ public class MicroservicesWorkflow
         );
 
         var updateUpstream = Workflow.ExecuteActivityAsync(
-            () => MicroserviceActivities.UpdateUpstream(),
+            (MicroserviceActivities a) => a.UpdateUpstream(),
             new ActivityOptions
             {
                 StartToCloseTimeout = TimeSpan.FromMinutes(5),
@@ -60,7 +60,7 @@ public class MicroservicesWorkflow
         );
 
         var transitionToApproved = Workflow.ExecuteActivityAsync(
-            () => MicroserviceActivities.TransitionToApproved(),
+            (MicroserviceActivities a) => a.TransitionToApproved(),
             new ActivityOptions
             {
                 StartToCloseTimeout = TimeSpan.FromMinutes(5),

--- a/temporal-examples/workflows/MicroserviceActivities.cs
+++ b/temporal-examples/workflows/MicroserviceActivities.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Temporalio.Activities;
 
 namespace Workflows;
@@ -23,6 +24,9 @@ public class MicroserviceActivities
     [Activity]
     public static async Task<Result<string>> CreateSecondaryCosts()
     {
+        ActivityExecutionContext.Current.Logger.LogInformation(
+            "Executing activity for OpenTelemetry sample."
+        );
         await Task.Delay(3000);
         return new Result<string> { Value = "Created" };
     }

--- a/temporal-examples/workflows/MicroserviceActivities.cs
+++ b/temporal-examples/workflows/MicroserviceActivities.cs
@@ -8,33 +8,58 @@ namespace Workflows;
 // allow a separation.
 public class MicroserviceActivities
 {
-    [Activity]
-    public static async Task<bool> ValidateTransition(string transitionLocation)
+    private readonly ILogger<MicroserviceActivities> _logger;
+
+    public MicroserviceActivities(ILogger<MicroserviceActivities> logger)
     {
+        _logger = logger;
+    }
+
+    [Activity]
+    public async Task<bool> ValidateTransition(string transitionLocation)
+    {
+        var duration = 2000;
+        _logger.LogInformation("Starting delay: {Duration}", duration);
         await Task.Delay(1000);
+        _logger.LogInformation("Finished delay");
         return true;
     }
 
     [Activity]
-    public static async Task TransitionToApproved()
+    public async Task TransitionToApproved()
     {
+        ActivityExecutionContext.Current.Logger.LogInformation(
+            "Executing TransitionToApproved activity for OpenTelemetry sample."
+        );
+        var duration = 1500;
+        _logger.LogInformation("Starting delay: {Duration}", duration);
         await Task.Delay(1500);
+        _logger.LogInformation("Finished delay");
     }
 
     [Activity]
-    public static async Task<Result<string>> CreateSecondaryCosts()
+    public async Task<Result<string>> CreateSecondaryCosts()
     {
         ActivityExecutionContext.Current.Logger.LogInformation(
-            "Executing activity for OpenTelemetry sample."
+            "Executing CreateSecondaryCosts activity for OpenTelemetry sample."
         );
-        await Task.Delay(3000);
+        var duration = 3000;
+        _logger.LogInformation("Starting delay: {Duration}", duration);
+        await Task.Delay(duration);
+        _logger.LogInformation("Finished delay");
         return new Result<string> { Value = "Created" };
     }
 
     [Activity]
-    public static async Task<Result<string>> UpdateUpstream()
+    public async Task<Result<string>> UpdateUpstream()
     {
-        await Task.Delay(5000);
+        ActivityExecutionContext.Current.Logger.LogInformation(
+            "Executing UpdateUpstream activity for OpenTelemetry sample."
+        );
+        var duration = 5000;
+        _logger.LogInformation("Starting delay: {Duration}", duration);
+        await Task.Delay(duration);
+        _logger.LogInformation("Finished delay");
         return new Result<string> { Value = "updated" };
     }
 


### PR DESCRIPTION
Allows you to see the Microservices worker logs in Prometheus, Grafana and Aspire. 

Annoyingly in Aspire we see all the logs under "temporal-worker" but will discuss to see if that's worth separating out